### PR TITLE
Added function to run commands via the Windows task scheduler

### DIFF
--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -518,7 +518,10 @@ class esxiVm:
         # CAUSING SOME PRIV ESC ATTACKS TO FAIL.  SCHEDULING THE PAYLOAD FIXES THAT.  FYI, RUNAS 
         # DOES NOT
         schedTime = datetime.datetime.now() + datetime.timedelta(seconds=secDelay)
-        schedTimeStr = str(schedTime.hour) + ":" + str(schedTime.minute)
+        strMinutes = str(schedTime.minute)
+        if len(strMinutes) < 2:
+            strMinutes = '0' + strMinutes
+        schedTimeStr = str(schedTime.hour) + ":" + strMinutes
         self.server.logMsg("SCEDULE TIME FOR EXECUTION = " + schedTimeStr)
         schedPrefixStr = r"c:\windows\system32\schtasks.exe /create /tn test4 /ST " + schedTimeStr + " /SC once /tr "
         schedPrefixList = schedPrefixStr.split()

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -1,8 +1,11 @@
 
 from pyVim.connect import SmartConnect, Disconnect
 from pyVmomi import vim, vmodl
+from string import ascii_lowercase
+from random import choice
 
 import datetime
+import random
 import atexit
 import requests
 from socket import error as SocketError
@@ -517,13 +520,14 @@ class esxiVm:
         # THE POINT HERE IS THAT WHEN VMWARE TOOLS RUNS EXEs, IT DOES SO WITH VERY LIMITED PRIVS
         # CAUSING SOME PRIV ESC ATTACKS TO FAIL.  SCHEDULING THE PAYLOAD FIXES THAT.  FYI, RUNAS 
         # DOES NOT
+        strTaskName = 'VM-' + ''.join(choice(ascii_lowercase) for i in range(12))
         schedTime = datetime.datetime.now() + datetime.timedelta(seconds=secDelay)
         strMinutes = str(schedTime.minute)
         if len(strMinutes) < 2:
             strMinutes = '0' + strMinutes
         schedTimeStr = str(schedTime.hour) + ":" + strMinutes
         self.server.logMsg("SCEDULE TIME FOR EXECUTION = " + schedTimeStr)
-        schedPrefixStr = r"c:\windows\system32\schtasks.exe /create /tn test4 /ST " + schedTimeStr + " /SC once /tr "
+        schedPrefixStr = r"c:\windows\system32\schtasks.exe /create /tn " + strTaskName + " /ST " + schedTimeStr + " /SC once /tr "
         schedPrefixList = schedPrefixStr.split()
         schedPrefixList.append("\"" + ' '.join(cmdAndArgList) + "\"")
         return self.runCmdOnGuest(schedPrefixList)


### PR DESCRIPTION
Running payloads using the vmware tools execution process results in strange permissions and causes privescs to fail.  When they are added through the task scheduler, they run fine.  I tried using runas, but that fail, too.

Not sure what's happening.  The user is the same, but there's got to be some inherited permission from the vmwaretools process that is affecting the behavior.

Testing will rely in a coming PR to the automated-testing repo.