### PR TITLE
Fix revertToSnapshotByName

### DIFF
--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -469,7 +469,7 @@ class esxiVm:
         self.server.logMsg("RESETTING VM " + self.vmName)
         self.getSnapshots()
         for snapshotObject in self.snapshotList:
-            if snapshotName.lower() in snapshotObject[0].name.lower():
+            if snapshotName.strip() == snapshotObject[0].name.strip():
                 self.server.logMsg("REVERTING VM TO " + snapshotObject[0].name)
                 return self.revertToSnapshot(snapshotObject[0].snapshot)
         return None

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -465,11 +465,11 @@ class esxiVm:
     def revertToSnapshot(self, snapshotObj):
         return self.waitForTask(snapshotObj.RevertToSnapshot_Task())
 
-    def revertToSnapshotByName(self, snapshotObj):
+    def revertToSnapshotByName(self, snapshotName):
         self.server.logMsg("RESETTING VM " + self.vmName)
         self.getSnapshots()
         for snapshotObject in self.snapshotList:
-            if 'testing_base' in snapshotObject[0].name.lower():
+            if snapshotName.lower() in snapshotObject[0].name.lower():
                 self.server.logMsg("REVERTING VM TO " + snapshotObject[0].name)
                 return self.revertToSnapshot(snapshotObject[0].snapshot)
         return None


### PR DESCRIPTION
This fixes a bug where we never actually bothered to try and see if the name string parameter was in the list, but always reset to `testing_base` because apparently, I'm not very smart.

Testing steps:
- [x] run the revertToSnapshotByName() function passing it a snapshot name that exists, but is not testing_base