### PR TITLE
Add script to manage windows services (and stuff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 /*.egg-info
 /.idea
 /*.log
-/*.log
+/logs/
 /samples/*.log
 /samples/logs/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 /*.egg-info
 /.idea
 /*.log
+/*.log
 /samples/*.log
+/samples/logs/*.log

--- a/samples/action_scripts/commands.json
+++ b/samples/action_scripts/commands.json
@@ -1,0 +1,252 @@
+{
+	"UAC_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"%SystemRoot%\\System32\\reg.exe",
+						"ADD",
+						"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+						"/v",
+						"EnableLUA",
+						"/t",
+						"REG_DWORD",
+						"/d",
+						"0",
+						"/f"
+					]
+				]
+		},
+	"UAC_ENABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"%SystemRoot%\\System32\\reg.exe",
+						"ADD",
+						"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+						"/v",
+						"EnableLUA",
+						"/t",
+						"REG_DWORD",
+						"/d",
+						"1",
+						"/f"
+					]
+				]
+		},
+	"SMB1_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+					"cmd.exe",
+					"/k",
+					"%SystemRoot%\\System32\\reg.exe",
+					"ADD",
+					"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters",
+					"/v",
+					"SMB1",
+					"/t",
+					"REG_DWORD",
+					"/d",
+					"0",
+					"/f"
+					]
+				]
+		},
+	"SMB1_ENABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+					"cmd.exe",
+					"/k",
+					"%SystemRoot%\\System32\\reg.exe",
+					"ADD",
+					"HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters",
+					"/v",
+					"SMB1",
+					"/t",
+					"REG_DWORD",
+					"/d",
+					"1",
+					"/f"
+					]
+				]
+		},
+	"WSUS_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+					"cmd.exe",
+					"/k",
+					"%SystemRoot%\\System32\\reg.exe",
+					"ADD",
+					"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+					"/v",
+					"NoAutoUpdate",
+					"/t",
+					"REG_DWORD",
+					"/d",
+					"1",
+					"/f"
+					]
+				]
+		},
+	"WSUS_ENABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+					"cmd.exe",
+					"/k",
+					"%SystemRoot%\\System32\\reg.exe",
+					"DELETE",
+					"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\AU",
+					"/v",
+					"NoAutoUpdate",
+					"/f"
+					]
+				]
+		},
+	"FIREWALL_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"%SystemRoot%\\System32\\netsh",
+						"advfirewall",
+						"set",
+						"allprofiles",
+						"state",
+						"off"
+					]
+				]
+		},
+	"FIREWALL_ENABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"%SystemRoot%\\System32\\netsh",
+						"advfirewall",
+						"set",
+						"allprofiles",
+						"state",
+						"on"
+					]
+				]
+		},
+	"DEFENDER_SIGUPDATE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"\"%PROGRAMFILES%\\Windows Defender\\MpCmdRun.exe\"",
+						"-SignatureUpdate"
+					]
+				],
+			"WAIT_SECONDS":		300
+		},
+	"DEFENDER_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+				[
+					[
+						"cmd.exe",
+						"/k",
+						"%SystemRoot%\\System32\\reg.exe",
+						"ADD",
+						"\"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\"",
+						"/v",
+						"DisableAntiSpyware",
+						"/t",
+						"REG_DWORD",
+						"/d",
+						"1",
+						"/f"
+					]
+				]
+		},
+	"DEFENDER_ENABLE":
+		{
+			"TYPE": 		"SCRIPT",
+			"FILENAME":		"./action_scripts/defender_enable.vbs",
+			"INTERPRETER":		"%SystemRoot%\\System32\\cscript.exe",
+			"UPLOAD_DIR": 		"C:\\Windows\\Temp",
+			"SUCCESS_TYPE":		"PROCESS",
+			"SUCCESS_METRIC":	"MsMpEng.exe"
+		},
+	"AUTOLOGIN_ENABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+					[
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"ADD",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"DefaultUserName",
+							"-t",
+							"REG_SZ",
+							"/d",
+							"VM_USERNAME",
+							"/f"
+						],
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"ADD",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"DefaultPassword",
+							"-t",
+							"REG_SZ",
+							"/d",
+							"VM_PASSWORD",
+							"/f"
+						],
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"ADD",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"AutoAdminLogon",
+							"/t",
+							"REG_DWORD",
+							"/d",
+							"1",
+							"/f"
+						]
+					]
+		}
+
+}

--- a/samples/action_scripts/commands.json
+++ b/samples/action_scripts/commands.json
@@ -247,6 +247,46 @@
 							"/f"
 						]
 					]
+		},
+	"AUTOLOGIN_DISABLE":
+		{
+			"TYPE": 	"COMMANDS",
+			"COMMANDS":
+					[
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"DELETE",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"DefaultUserName",
+							"/f"
+						],
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"DELETE",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"DefaultPassword",
+							"/f"
+						],
+						[
+							"cmd.exe",
+							"/k",
+							"%SystemRoot%\\System32\\reg.exe",
+							"ADD",
+							"\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\"",
+							"/v",
+							"AutoAdminLogon",
+							"/t",
+							"REG_DWORD",
+							"/d",
+							"0",
+							"/f"
+						]
+					]
 		}
-
 }

--- a/samples/action_scripts/defender_enable.vbs
+++ b/samples/action_scripts/defender_enable.vbs
@@ -1,0 +1,19 @@
+Set WshShell = Wscript.CreateObject("Wscript.Shell")
+Dim regCmd: regCmd = "%SystemRoot%\\System32\\reg.exe DELETE ""HKLM\SOFTWARE\Policies\Microsoft\Windows Defender"" /v DisableAntiSpyware /f"
+Wscript.Echo regCmd
+WshShell.Run(regCmd)
+Wscript.Sleep 5000
+Dim netCmd: netCmd = "%SystemRoot%\\System32\\net.exe start windefend"
+Wscript.Echo netCmd
+WshShell.Run(netCmd)
+Wscript.Sleep 5000
+WshShell.Run """%PROGRAMFILES%\Windows Defender\MSASCui.exe""", 9
+Wscript.Sleep 5000
+WshShell.SendKeys "%{C}"
+Wscript.Sleep 5000
+WshShell.SendKeys "%{F4}"
+Wscript.Sleep 5000
+WshShell.Run """%PROGRAMFILES%\Windows Defender\MSASCui.exe""", 9
+Wscript.Sleep 5000
+WshShell.SendKeys "{ENTER}"
+

--- a/samples/clearSnapshots.py
+++ b/samples/clearSnapshots.py
@@ -1,0 +1,32 @@
+import argparse
+import vm_automation
+
+
+def deleteSnapshots(vm, snapshotSubstring):
+    vm.getSnapshots()
+    for snapshot in vm.snapshotList:
+        if snapshotSubstring in snapshot[0].name:
+            vm.deleteSnapshot(snapshot[0].name)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-k", "--keyword", help="VM search parameter")
+    parser.add_argument("-ss", "--snapshotSubstring", help="snapshot substring")
+    parser.add_argument("hypervisorConfig", help="json hypervisor config")
+    
+    args = parser.parse_args()
+    if args.keyword != None:
+        searchTerm = args.keyword
+    if args.snapshotSubstring != None:
+        snapshotSubstring = args.snapshotSubstring
+
+    hypervisorDic = {}
+    vmServer = vm_automation.esxiServer.createFromFile(args.hypervisorConfig, './snapshot.log')
+    if vmServer != None:
+        vmServer.enumerateVms()
+        for vm in vmServer.vmList:
+            if (args.keyword == None) or (searchTerm in vm.vmName):
+                deleteSnapshots(vm, snapshotSubstring)
+    
+if __name__ == "__main__":
+    main()

--- a/samples/getVmList.py
+++ b/samples/getVmList.py
@@ -12,10 +12,6 @@ def main():
     CREATE SERVER
     """
     logFile = './service_management.log'
-    try:
-        os.remove(logFile)
-    except:
-        pass
     vmServer = vm_automation.esxiServer.createFromFile(args.hypervisorConfig, logFile)
     if vmServer == None:
         print("VM SERVER CREATION FAILED")

--- a/samples/getVmList.py
+++ b/samples/getVmList.py
@@ -1,0 +1,29 @@
+import argparse
+import vm_automation
+import sampleLib
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-k", "--keyword", help="VM search parameter")
+    parser.add_argument("hypervisorConfig", help="json hypervisor config")
+    args = parser.parse_args()
+    
+    """
+    CREATE SERVER
+    """
+    logFile = './service_management.log'
+    try:
+        os.remove(logFile)
+    except:
+        pass
+    vmServer = vm_automation.esxiServer.createFromFile(args.hypervisorConfig, logFile)
+    if vmServer == None:
+        print("VM SERVER CREATION FAILED")
+        return 0
+    
+    vmList = sampleLib.makeVmList(vmServer, args.keyword, None)
+    for vm in vmList:
+        print(vm.vmName)
+
+if __name__ == "__main__":
+    main()

--- a/samples/manageServices.py
+++ b/samples/manageServices.py
@@ -1,0 +1,262 @@
+import argparse
+import vm_automation
+import multiprocessing
+import os
+import time
+from pyVmomi import vim
+import sampleLib
+from Crypto.SelfTest.Random.test__UserFriendlyRNG import multiprocessing
+
+def listCommands(commandDictionary):
+        for key, value in commandDictionary.iteritems():
+            print(key)
+        return 1
+
+def replaceUsername(actionData, username):
+    if actionData['TYPE'] == 'COMMANDS':
+        for i in range(len(actionData['COMMANDS'])):
+            for j in range(len(actionData['COMMANDS'][i])):
+                while 'VM_USERNAME' in actionData['COMMANDS'][i][j]:
+                    actionData['COMMANDS'][i][j] = actionData['COMMANDS'][i][j].replace("VM_USERNAME", username)
+                    
+def replacePassword(actionData, password):
+    if actionData['TYPE'] == 'COMMANDS':
+        for i in range(len(actionData['COMMANDS'])):
+            for j in range(len(actionData['COMMANDS'][i])):
+                while 'VM_PASSWORD' in actionData['COMMANDS'][i][j]:
+                    actionData['COMMANDS'][i][j] = actionData['COMMANDS'][i][j].replace("VM_PASSWORD", password)
+
+def runCommands(vmObject, actionData):
+    for command in actionData['COMMANDS']:
+        for i in range(5):
+            retVal = True
+            try:
+                if vmObject.runCmdOnGuest(command) == False:
+                    retVal = False
+            except vim.fault.InvalidState:
+                retVal = False
+                continue
+            break
+    return retVal
+
+def runScript(vmObject, actionData):
+    localScriptName = actionData['FILENAME']
+    interpreter = actionData['INTERPRETER']
+    remoteScriptName = actionData['UPLOAD_DIR'] + "\\" + localScriptName.split('/')[-1]
+    retVal = False
+    try:
+        retVal = vmObject.uploadAndRun(localScriptName, remoteScriptName, interpreter, True)
+    except Exception as e:
+        print("CAUGHT EXCEPTION: " + str(e))
+        retVal = False
+    return retVal
+
+def checkSuccess(vmObject, actionData):
+    if 'SUCCESS_TYPE' in actionData and 'SUCCESS_METRIC' in actionData:
+        if actionData['SUCCESS_TYPE'] == 'PROCESS':
+            retVal = sampleLib.checkForProcess(vmObject, actionData['SUCCESS_METRIC'])
+    else:
+        print("NO SUCCESS_TYPE OR SUCCESS METRIC IN THE DICTIONARY")
+        retVal = False
+    return retVal
+
+def executeAction(vmObject, actionData):
+    if 'WAIT_SECONDS' in actionData:
+        scheduleDelay = actionData['WAIT_SECONDS']
+    else:
+        scheduleDelay = 30
+    vmObject.powerOn()
+    vmReady = False
+    retVal = True
+    while vmReady is False:
+        vmReady = vmObject.waitForVmToBoot()
+    time.sleep(10)
+    if actionData['TYPE'] == "COMMANDS":
+        retVal = runCommands(vmObject, actionData)
+    if actionData['TYPE'] == "SCRIPT":
+        retVal = runScript(vmObject, actionData)
+    time.sleep(scheduleDelay)
+    if 'SUCCESS_TYPE' in actionData and 'SUCCESS_METRIC' in actionData:
+        retVal = checkSuccess(vmObject, actionData)
+    vmObject.vmObject.ShutdownGuest()
+    time.sleep(10)
+    vmObject.powerOff()
+    return retVal
+    
+def parallelRun(serverConfig, vmName, username, password, actionData, snapshotName):
+    """
+    CREATE SERVER
+    """
+    logFile = './logs/service_management_' + vmName + '.log'
+    try:
+        os.remove(logFile)
+    except:
+        pass
+
+    try:
+        logFileObj = open(logFile, 'w')
+        logFileObj.write(vmName)
+        logFileObj.close()
+    except:
+        print("FAILED TO OPEN " + logFile)
+    vmServer = vm_automation.esxiServer.createFromFile(serverConfig, logFile)
+    if vmServer == None:
+        print("VM SERVER CREATION FAILED")
+        return 0
+    
+    """
+    GET VM OBJECT
+    """
+    vmObject = sampleLib.getVmObjectFromName(vmServer, vmName)
+    vmObject.setUsername(username)
+    vmObject.setPassword(password)
+    
+    if vmObject == None:
+        retVal = False
+    else:
+        retVal = executeAction(vmObject, actionData)
+        if retVal != True:
+            reVal = False
+    if retVal:
+        vmObject.takeSnapshot(snapshotName)
+    return (vmName, retVal)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--action", help="action to run")
+    parser.add_argument("-k", "--keyword", help="VM search parameter")
+    parser.add_argument("-lc", "--listCommands", help="list available commands", action="store_true")
+    parser.add_argument("-sn", "--snapshotName", help="name if snapshot to create after changes")
+    parser.add_argument("-vf", "--vmFile", help="text file with vms to apply changes")
+    parser.add_argument("-w", "--wait", help="override the time (in seconds) to wait after running commands/script")
+    parser.add_argument("-cf", "--credsFile", help="credentials file for logging into the vm")
+    parser.add_argument("-af", "--actionFile", help="json file containing commands/actions")
+    parser.add_argument("-un", "--username", help="vm username")
+    parser.add_argument("-pw", "--password", help="vm password")
+    parser.add_argument("-t", "--threads", help="concurrent vms to alter")
+    parser.add_argument("hypervisorConfig", help="json hypervisor config")
+    args = parser.parse_args()
+
+    """
+    PREP COMMAND FILE
+    """
+    if args.actionFile != None:
+        commandFile = args.actionFile
+    else:
+        commandFile = "./action_scripts/commands.json"
+    commandDictionary = sampleLib.loadJsonFile(commandFile)
+    if commandDictionary == None:
+        print("FAILED TO LOAD COMMANDS")
+        return 0
+    """
+    IF THEY ASK TO LIST COMMANDS, DO IT AND EXIT
+    """
+    if args.listCommands:
+        return listCommands(commandDictionary)
+    
+    """
+    ENSURE THE COMMAND EXISTS
+    """
+    if args.action not in commandDictionary:
+        print("SELECTED ACTION NOT LISTED IN COMMAND FILE")
+        listCommands(commandDictionary)
+        return 0
+    
+    """
+    CHECK THAT WE HAVE REQUIRED CREDS SOMEHOW
+    """
+    if (args.username == None or args.password == None) and args.credsFile == None:
+        print("VM CREDENTIALS REQUIRED FOR THIS OPERATION")
+        exit(0)
+
+    credsDictionary = None
+    if args.credsFile != None:
+        credsDictionary = sampleLib.loadJsonFile(args.credsFile)
+        if credsDictionary == None:
+            print("FAILED TO LOAD CREDS FILE")
+            exit(0)
+    
+    replaceUsername(commandDictionary[args.action], args.username)
+    replacePassword(commandDictionary[args.action], args.password)
+    """
+    UPDATE WAIT, IF REQUIRED
+    """
+    if args.wait != None:
+        commandDictionary[args.action]['WAIT_SECONDS'] = int(args.wait)
+        
+    """
+    CREATE SERVER
+    """
+    logFile = './logs/service_management.log'
+    try:
+        os.remove(logFile)
+    except:
+        pass
+    vmServer = vm_automation.esxiServer.createFromFile(args.hypervisorConfig, logFile)
+    if vmServer == None:
+        print("VM SERVER CREATION FAILED")
+        return 0
+    
+    """
+    GENERATE LIST OF VMS THAT NEED TO CHANGE
+    """
+    vmsToChange = sampleLib.makeVmList(vmServer, args.keyword, args.vmFile)
+    
+    """
+    ARE WE USING THREADS?
+    """
+    if args.threads != None:
+        """
+        EXECUTE IN PARALLEL
+        """
+        pool = multiprocessing.Pool(int(args.threads))
+        print("USING " + str(int(args.threads)) + " THREADS")
+        vmNames = []
+        for vm in vmsToChange:
+            vmNames.append(vm.vmName)
+        try:
+            results = [pool.apply_async(parallelRun, 
+                                        args = (args.hypervisorConfig, \
+                                                vmName, \
+                                                args.username, \
+                                                args.password, \
+                                                commandDictionary[args.action], \
+                                                args.snapshotName)) \
+                                        for vmName in vmNames]
+        except Exception as e:
+            print("CAUGHT EXCEPTION " + str(e))
+        pool.close()
+        pool.join()
+        actualResults = []
+        for i in results:
+            try:
+                actualResults.append(i.get())
+            except Exception as e:
+                print("EXCEPTION GENERATED: " + str(e))
+                continue
+        for j in actualResults:
+            print(str(j))
+    else:
+        """
+        RUN THE COMMANDS IN SERIAL
+        """
+        for vm in vmsToChange:
+            if credsDictionary != None and vm.vmName in credsDictionary:
+                vm.setUsername(credsDictionary[vm.vmName]['USERNAME'])
+                vm.setPassword(credsDictionary[vm.vmName]['PASSWORD'])
+            else:
+                vm.setUsername(args.username)
+                vm.setPassword(args.password)
+            if vm.getUsername() == None or vm.getPassword() == None:
+                print ("NO CREDS AVAILABLE FOR " + vm.vmName)
+            else:
+                if executeAction(vm, commandDictionary[args.action]):
+                    retVal = True
+                    if args.snapshotName != None:
+                        vm.takeSnapshot(args.snapshotName)
+                else:
+                    retVal = False
+            print(str((vm.vmName, retVal)))
+    
+if __name__ == "__main__":
+    main()

--- a/samples/sampleLib.py
+++ b/samples/sampleLib.py
@@ -1,0 +1,58 @@
+import json
+import vm_automation
+
+def checkForProcess(vmObject, processName):
+    vmObject.updateProcList()
+    if processName in ' '.join(vmObject.procList):
+        return True
+    else:
+        return False
+
+def getVmObjectFromName(vmServer, vmName):
+    vmServer.enumerateVms()
+    for vm in vmServer.vmList:
+        if vmName == vm.vmName:
+            return vm
+    return None
+
+def loadJsonFile(fileName):
+    try:
+        fileObject = open(fileName, 'r')
+        fileStr = fileObject.read()
+        fileObject.close()
+    except IOError as e:
+        print("UNABLE TO OPEN FILE: " + str(fileName) + '\n' + str(e))
+        return None
+    try:
+        fileDic = json.loads(fileStr)
+    except Exception as e:
+        print("UNABLE TO PARSE FILE: " + str(fileName) + '\n' + str(e))
+        return None
+    return fileDic
+
+def makeVmList(vmServer, keywordArg, fileArg):
+    vmList = []
+    if fileArg != None:
+        vmFileObj = open(fileArg, 'r')
+        desiredVms = vmFileObj.read().splitlines()
+        vmFileObj.close()
+        vmServer.enumerateVms()
+        for vm  in vmServer.vmList:
+            if vm.vmName in desiredVms:
+                vmList.append(vm)
+    if keywordArg != None:
+        vmServer.enumerateVms()
+        for vm in vmServer.vmList:
+            if keywordArg in vm.vmName:
+                vmList.append(vm)
+    return vmList
+
+def waitForProcess(vmObject, procName, timeout = 600):
+    retVal = False
+    for i in range(timeout/5):
+        vmObject.updateProcList()
+        if procName in ' '.join(vmObject.procList):
+            retVal = True
+            break
+        time.sleep(5)
+    return retVal

--- a/samples/sampleLib.py
+++ b/samples/sampleLib.py
@@ -1,5 +1,4 @@
 import json
-import vm_automation
 
 def checkForProcess(vmObject, processName):
     vmObject.updateProcList()
@@ -7,13 +6,6 @@ def checkForProcess(vmObject, processName):
         return True
     else:
         return False
-
-def getVmObjectFromName(vmServer, vmName):
-    vmServer.enumerateVms()
-    for vm in vmServer.vmList:
-        if vmName == vm.vmName:
-            return vm
-    return None
 
 def loadJsonFile(fileName):
     try:
@@ -49,7 +41,10 @@ def makeVmList(vmServer, keywordArg, fileArg):
 
 def waitForProcess(vmObject, procName, timeout = 600):
     retVal = False
-    for i in range(timeout/5):
+    waitCount = 1
+    if timeout > 0:
+        waitCount = timeout/5
+    for i in range(waitCount):
         vmObject.updateProcList()
         if procName in ' '.join(vmObject.procList):
             retVal = True

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -532,7 +532,7 @@ class esxiVm:
                 cmdpid = content.guestOperationsManager.processManager.StartProgramInGuest(vm=self.vmObject,
                                                                                            auth=creds,
                                                                                            spec=cmdspec)
-                retVal = cmdpid
+                retVal = False
                 self.server.logMsg("LAUNCHING '" + ' '.join(cmdAndArgList) + "' ON " + self.vmName)
                 retVal = True
             except vim.fault.InvalidGuestLogin as e:

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -198,6 +198,13 @@ class esxiServer:
         self.fullName = content.about.fullName
         return self.fullName
 
+    def getVmByName(self, vmName):
+        self.enumerateVms()
+        for vm in self.vmList:
+            if vmName == vm.vmName:
+                return vm
+        return None
+
 class esxiVm:
     def __init__(self, serverObject, vmObject):
         self.server =           serverObject
@@ -402,7 +409,7 @@ class esxiVm:
         return self.vmUsername
 
     def getPassword(self):
-        return self.vmPassword^M
+        return self.vmPassword
 
     def isTestVm(self):
         return self.testVm

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -401,9 +401,8 @@ class esxiVm:
     def getUsername(self):
         return self.vmUsername
 
-    def getPassword(self):^M
+    def getPassword(self):
         return self.vmPassword^M
-
 
     def isTestVm(self):
         return self.testVm

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -401,6 +401,10 @@ class esxiVm:
     def getUsername(self):
         return self.vmUsername
 
+    def getPassword(self):^M
+        return self.vmPassword^M
+
+
     def isTestVm(self):
         return self.testVm
 
@@ -640,16 +644,18 @@ class esxiVm:
                 retVal = True
         return retVal
 
-    def uploadAndRun(self, srcFile, dstFile, remoteInterpreter = None):
+    def uploadAndRun(self, srcFile, dstFile, remoteInterpreter = None, useCmdShell = False):
         """
         THIS JUST COMBINES THE UPLOAD AND EXECUTE FUNCTIONS, BUT IF THE VM IS 'NIX, IT ALSO
         CHMODS THE FILE SO WE CAN EXECUTE IT
         """
         self.server.logMsg("SOURCE FILE = " + srcFile + "; DESTINATION FILE = " + dstFile)
+        remoteCmd = []
+        if useCmdShell == True:
+            remoteCmd.extend(['cmd.exe', '/k'])
         if remoteInterpreter!= None:
-            remoteCmd = [remoteInterpreter, dstFile]
-        else:
-            remoteCmd = [dstFile]
+            remoteCmd.append(remoteInterpreter)
+        remoteCmd.append(dstFile)
         if not self.uploadFileToGuest(srcFile, dstFile):
             self.server.logMsg("[FATAL ERROR]: FAILED TO UPLOAD " + srcFile + " TO " + self.vmName)
             return False


### PR DESCRIPTION
Primarily, this PR adds the manageServices script into the sample directory.  As we got increasing demand to customize VMs as a block, this script is made to try and support customization in a highly extensible way.  

The script is just a wrapper for parallel execution of commands or scripts across large numbers of VMs.

The commands.json file contains the choices and commands, or the location of the script.  To incorporate another command, all anyone needs to do it add it to the commands.json file.  If (s)he wants to deploy a script, just add the script to the action_scripts folder, add the command in json and specify the interpreter to use when launching the script.

Currently supported are:
Enable/Disable Windows Firewall
Enable/Disable SMBv1
Enable/Disable Windows Updates
Enable/Disable Windows Defender (does not work on Windows 1703 or Windows 81, yet)
Enable/Disable Autologin

For future work, it might be nice to leverage the cpe stuff @jmartin-r7 recently added to track supported OSes and methods.

I'd also like to see cases here where we pirate chef/vagrant scripts as well as just doing some cool setup stuff.

Other stuff this does is to add a handy script to help generate vm lists, a sampleLib file with some useful functions, and a lazy way to clear snapshots like we use in testing.

## Example:
Help:
```
python manageServices.py -h
usage: manageServices.py [-h] [-a ACTION] [-k KEYWORD] [-lc]
                         [-sn SNAPSHOTNAME] [-vf VMFILE] [-w WAIT]
                         [-cf CREDSFILE] [-af ACTIONFILE] [-un USERNAME]
                         [-pw PASSWORD] [-t THREADS]
                         hypervisorConfig

positional arguments:
  hypervisorConfig      json hypervisor config

optional arguments:
  -h, --help            show this help message and exit
  -a ACTION, --action ACTION
                        action to run
  -k KEYWORD, --keyword KEYWORD
                        VM search parameter
  -lc, --listCommands   list available commands
  -sn SNAPSHOTNAME, --snapshotName SNAPSHOTNAME
                        name if snapshot to create after changes
  -vf VMFILE, --vmFile VMFILE
                        text file with vms to apply changes
  -w WAIT, --wait WAIT  override the time (in seconds) to wait after running
                        commands/script
  -cf CREDSFILE, --credsFile CREDSFILE
                        credentials file for logging into the vm
  -af ACTIONFILE, --actionFile ACTIONFILE
                        json file containing commands/actions
  -un USERNAME, --username USERNAME
                        vm username
  -pw PASSWORD, --password PASSWORD
                        vm password
  -t THREADS, --threads THREADS
                        concurrent vms to alter

```
List available commands:
```
python manageServices.py -lc x
DEFENDER_SIGUPDATE
UAC_ENABLE
WSUS_DISABLE
DEFENDER_DISABLE
UAC_DISABLE
AUTOLOGIN_ENABLE
SMB1_ENABLE
FIREWALL_DISABLE
SMB1_DISABLE
WSUS_ENABLE
FIREWALL_ENABLE
DEFENDER_ENABLE

```
Turn on Windows firewall for all windows 10 VMs and add a snapshot for that new state called "FIREWALL_ENABLED" updating 5 vms at a time:
```
python manageServices.py -a FIREWALL_ENABLE -sn FIREWALL_ENABLED -k Win10 -un vagrant -pw vagrant -t 5 ../../payload-testing/config/laptop_lab.json 
USING 5 THREADS
('TEST_Win10x86', True)
('TEST_Win10x64_1703', True)
('Win10x64_1703', True)
('Win10x64_1607', True)
('Win10x86_1511', True)
('Win10x86_1703', True)
('Win10x86', True)
('Win10x64_1511', True)
('Win10x86_1607', True)
('Win10x64', True)

```


