### PR TITLE
Add ability to upload/run exes as part of manageServices

### DIFF
--- a/samples/action_scripts/commands.json
+++ b/samples/action_scripts/commands.json
@@ -197,8 +197,38 @@
 			"INTERPRETER":		"%SystemRoot%\\System32\\cscript.exe",
 			"UPLOAD_DIR": 		"C:\\Windows\\Temp",
 			"SUCCESS_TYPE":		"PROCESS",
-			"SUCCESS_METRIC":	"MsMpEng.exe"
+			"SUCCESS_METRIC":	"MsMpEng.exe",
+			"WAIT_SECONDS":		300
+
 		},
+	"INSTALL_AVAST":
+		{
+			"TYPE": 		"EXE",
+			"FILENAME":		"./action_scripts/ninite_avast_installer.exe",
+			"UPLOAD_DIR": 		"C:\\Windows\\Temp",
+			"SUCCESS_TYPE":		"PROCESS",
+			"SUCCESS_METRIC":	"AvastSvc.exe",
+			"WAIT_SECONDS":		300
+		},
+	"INSTALL_MALWAREBYTES":
+		{
+			"TYPE": 		"EXE",
+			"FILENAME":		"./action_scripts/ninite_malwarebytes_installer.exe",
+			"UPLOAD_DIR": 		"C:\\Windows\\Temp",
+			"SUCCESS_TYPE":		"PROCESS",
+			"SUCCESS_METRIC":	"MBAMService.exe",
+			"WAIT_SECONDS":		300
+		},
+	"INSTALL_AVG":
+		{
+			"TYPE": 		"EXE",
+			"FILENAME":		"./action_scripts/ninite_avg_installer.exe",
+			"UPLOAD_DIR": 		"C:\\Windows\\Temp",
+			"SUCCESS_TYPE":		"PROCESS",
+			"SUCCESS_METRIC":	"AVGSvc.exe",
+			"WAIT_SECONDS":		300
+		},
+
 	"AUTOLOGIN_ENABLE":
 		{
 			"TYPE": 	"COMMANDS",

--- a/samples/manageServices.py
+++ b/samples/manageServices.py
@@ -56,6 +56,16 @@ def runScript(vmObject, actionData):
         print("CAUGHT EXCEPTION: " + str(e))
     return retVal
 
+def runExe(vmObject, actionData):
+    localFileName = actionData['FILENAME']
+    remoteFileName = actionData['UPLOAD_DIR'] + "\\" + localFileName.split('/')[-1]
+    retVal = False
+    try:
+        retVal = vmObject.uploadAndRun(localFileName, remoteFileName, "", True)
+    except Exception as e:
+        print("CAUGHT EXCEPTION: " + str(e))
+    return retVal
+
 
 def checkSuccess(vmObject, actionData):
     retVal = False
@@ -81,6 +91,8 @@ def executeAction(vmObject, actionData):
     try:
         if actionData['TYPE'] == "COMMANDS":
             retVal = runCommands(vmObject, actionData)
+        if actionData['TYPE'] == "EXE":
+            retVal = runExe(vmObject, actionData)
         if actionData['TYPE'] == "SCRIPT":
             retVal = runScript(vmObject, actionData)
         time.sleep(scheduleDelay)
@@ -178,6 +190,7 @@ def main():
         print("VM CREDENTIALS REQUIRED FOR THIS OPERATION")
         exit(0)
 
+    credsDictionary = None
     if args.credsFile is not None:
         credsDictionary = sampleLib.loadJsonFile(args.credsFile)
         if credsDictionary is None:


### PR DESCRIPTION
OK.....
To be quite honest, I do not know if this is the right way to go about this, but it works.  Functionally, this PR adds the ability to install AVG, AVAST, or MALWAREBYTES across a range of VMs.  To do it, I leveraged Ninite free installers, which are included in this PR.

I'm not entirely comfortable with including those binaries, but again, it helps the cows come home as it were, and I figured I'd throw this out as a talking point.  Likely, I think the path should be to back off individual installers, and simply allow for handing the script an exe to run on every VM along with a success metric.  Something like:

`python manageServices -k <keyword> -a RUN_EXE -e <your_exe> -sm <success_metric?> -sn <snapshot_name> -un <username> -pw <password> esxi_config.json`

Regardless, this works and gives people some options for building out software in ranges.