### PR TITLE
guard vmOS check for None

### DIFF
--- a/samples/sampleLib.py
+++ b/samples/sampleLib.py
@@ -37,6 +37,10 @@ def makeVmList(vmServer, keywordArg, fileArg):
         for vm in vmServer.vmList:
             if keywordArg in vm.vmName:
                 vmList.append(vm)
+    else:
+        vmServer.enumerateVms()
+        for vm in vmServer.vmList:
+            vmList.append(vm)
     return vmList
 
 def waitForProcess(vmObject, procName, timeout = 600):

--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -488,10 +488,13 @@ class esxiVm:
         self.uploadDir =        ""
         self.payloadList =      []
         self.resultDict =       {}
-        if '64-bit' in self.vmOS:
-            self.arch = 'x64'
+        if self.vmOS is not None:
+            if '64-bit' in self.vmOS:
+                self.arch = 'x64'
+            else:
+                self.arch = 'x86'
         else:
-            self.arch = 'x86'
+            self.arch = 'unknown'
 
     def waitForVmToBoot(self):
         # IS IT TURNED ON?


### PR DESCRIPTION
When creating an esxiVm object guard against a missing OS.