### PR TITLE
when taking snapshots guard license restrictions

### DIFF
--- a/vm_automation/esxiVm.py
+++ b/vm_automation/esxiVm.py
@@ -887,10 +887,15 @@ class esxiVm:
                      dumpMemory = False,
                      setQuiescent = False):
         self.server.logMsg("TAKING SNAPSHOT " + snapshotName + " ON " + self.vmName)
-        snapshotTask = self.vmObject.CreateSnapshot_Task(snapshotName,
-                                                      snapshotDescription,
-                                                      dumpMemory,
-                                                      setQuiescent)
+        try:
+            snapshotTask = self.vmObject.CreateSnapshot_Task(snapshotName,
+                                                          snapshotDescription,
+                                                          dumpMemory,
+                                                          setQuiescent)
+        except vim.fault.RestrictedVersion:
+            self.server.logMsg("[WARNING]: SNAPSHOTS NOT SUPPORTED FOR " + self.vmName + " ON TARGET")
+            return False
+
         if not asyncFlag:
             return self.waitForTask(snapshotTask)
         else:


### PR DESCRIPTION
Not all ESXI are created equal, when the API does not allows snapshot creation, log the error and return false.