### PR TITLE
Add install active directory install command

### DIFF
--- a/samples/action_scripts/commands.json
+++ b/samples/action_scripts/commands.json
@@ -318,5 +318,16 @@
 							"/f"
 						]
 					]
-		}
+		},
+
+	"INSTALL_ACTIVE_DIRECTORY_DOMAIN_SERVICES": {
+		"TYPE": "SCRIPT",
+		"TODO": "XXX: Confirm if relative paths for FILENAME work here on CI: ./action_scripts/install_active_directory_forest.ps1",
+		"FILENAME": "/r7-source/vm-automation/samples/action_scripts/install_active_directory_forest.ps1",
+		"INTERPRETER": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+		"UPLOAD_DIR": "C:\\Windows\\Temp",
+		"SUCCESS_TYPE": "PROCESS",
+		"SUCCESS_METRIC": "Microsoft.ActiveDirectory.WebServices.exe",
+		"WAIT_SECONDS": 1200
+	}
 }

--- a/samples/action_scripts/commands.json
+++ b/samples/action_scripts/commands.json
@@ -322,8 +322,7 @@
 
 	"INSTALL_ACTIVE_DIRECTORY_DOMAIN_SERVICES": {
 		"TYPE": "SCRIPT",
-		"TODO": "XXX: Confirm if relative paths for FILENAME work here on CI: ./action_scripts/install_active_directory_forest.ps1",
-		"FILENAME": "/r7-source/vm-automation/samples/action_scripts/install_active_directory_forest.ps1",
+		"FILENAME": "action_scripts/install_active_directory_forest.ps1",
 		"INTERPRETER": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
 		"UPLOAD_DIR": "C:\\Windows\\Temp",
 		"SUCCESS_TYPE": "PROCESS",

--- a/samples/action_scripts/install_active_directory_forest.ps1
+++ b/samples/action_scripts/install_active_directory_forest.ps1
@@ -25,15 +25,6 @@ secedit /export /cfg c:\secpol.cfg
 secedit /configure /db c:\windows\security\local.sdb /cfg c:\secpol.cfg /areas SECURITYPOLICY
 rm -force c:\secpol.cfg -confirm:$false
 
-##################################################################################
-# Disable Antivirus
-##################################################################################
-
-if (Get-Module -ListAvailable -Name Defender) {
-    Set-MpPreference -DisableRealtimeMonitoring $true
-    New-ItemProperty -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" -Name DisableAntiSpyware -Value 1 -PropertyType DWORD -Force
-}
-
 #####################################################################################
 # Forest installation
 #####################################################################################

--- a/samples/action_scripts/install_active_directory_forest.ps1
+++ b/samples/action_scripts/install_active_directory_forest.ps1
@@ -1,0 +1,87 @@
+# Enforce best practices in Powershell
+Set-StrictMode -Version 1.0
+# Exit if a cmdlet fails
+$ErrorActionPreference = "Stop"
+
+# Configuration
+$domain = "demo.local"
+$plaintextPassword = "vagrant"
+
+##################################################################################
+# Password policy configuration
+##################################################################################
+
+Write-Host -fore green $ 'Running password policy logic'
+
+# Ensure passwords never expire
+net accounts /maxpwage:unlimited
+
+# Disable automatic machine account password changes
+Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetLogon\Parameters' -Name DisablePasswordChange -Value 1
+
+# Allow weak passwords
+secedit /export /cfg c:\secpol.cfg
+(Get-Content C:\secpol.cfg).replace("PasswordComplexity = 1", "PasswordComplexity = 0") | Out-File C:\secpol.cfg
+secedit /configure /db c:\windows\security\local.sdb /cfg c:\secpol.cfg /areas SECURITYPOLICY
+rm -force c:\secpol.cfg -confirm:$false
+
+##################################################################################
+# Disable Antivirus
+##################################################################################
+
+if (Get-Module -ListAvailable -Name Defender) {
+    Set-MpPreference -DisableRealtimeMonitoring $true
+    New-ItemProperty -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" -Name DisableAntiSpyware -Value 1 -PropertyType DWORD -Force
+}
+
+#####################################################################################
+# Forest installation
+#####################################################################################
+
+Write-Host -fore green $ 'Running forest installation'
+
+$safeModeAdministratorPassword = ConvertTo-SecureString $plaintextPassword -AsPlainText -Force
+
+# Set local Administrator account password to stop the error:
+#   "The new domain cannot be created DC01: because the local Administrator account password does not meet requirements."
+Write-Host -fore green $ 'Setting local administrator password'
+Set-LocalUser `
+    -Name Administrator `
+    -AccountNeverExpires `
+    -Password $safeModeAdministratorPassword `
+    -PasswordNeverExpires:$true `
+    -UserMayChangePassword:$true
+
+Install-WindowsFeature AD-Domain-Services,RSAT-AD-AdminCenter,RSAT-ADDS-Tools -IncludeManagementTools -Verbose
+
+#
+# Install the Active Directory Domain Services (AD DS) environment
+#
+
+# Win32_operatingSystem ProductType
+#   Work Station (1)
+#   Domain Controller (2)
+#   Server (3)
+# https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-operatingsystem
+$isDomainController = (Get-WmiObject -Class Win32_operatingSystem).ProductType -Eq 2
+Write-Host -fore green $ 'IsDomainController='$isDomainController
+if (!$isDomainController) {
+    Write-Host -fore green $ 'Installing ADDS'
+    $netbios = $domain.split('.')[0].ToUpperInvariant()
+    Install-ADDSForest `
+        -CreateDnsDelegation:$false `
+        -DatabasePath "C:\Windows\NTDS" `
+        -DomainMode "Win2012R2" `
+        -DomainName $domain `
+        -DomainNetbiosName $netbios `
+        -ForestMode "Win2012R2" `
+        -InstallDns:$true `
+        -LogPath "C:\Windows\NTDS" `
+        -NoRebootOnCompletion:$false `
+        -SysvolPath "C:\Windows\SYSVOL" `
+        -Force:$true `
+        -SafeModeAdministratorPassword $safeModeAdministratorPassword `
+        -Verbose
+}
+
+Write-Host -fore green $ 'Finished forest installation'


### PR DESCRIPTION
Adds install active directory command script to vm-automation; which allows for testing Kerberos/AD environments

---

My testing steps were running this script locally against a windows 2016/2019 server box. Will be used by https://github.com/rapid7/metasploit-jenkins-jobs/pull/449

I then tested it with [vmware-automation](https://github.com/rapid7/vm-automation) project by first building the [metasploit-baseline-builder](https://github.com/rapid7/metasploit-baseline-builder) docker container:

```
cd metasploit-baseline-builder/docker
docker build -f Dockerfile -t metasploit-baseline-builder .
```

Creating an ESXi config in `~/helper_config.json`:

```
{
  "HYPERVISOR_TYPE": "ESXI",
  "HYPERVISOR_HOST": "10.x.x.x",
  "HYPERVISOR_USERNAME": "....",
  "HYPERVISOR_PASSWORD": "....",
  "HYPERVISOR_LISTENING_PORT": 443
}
```

Running a docker container from the Jenkins user, mounting vmware-automation and the esxi config:

```
cd vmware-automation
docker run -it -u jenkins -v $(pwd):/r7-source/vm-automation -v $(realpath ~/helper_config.json):/r7-source/helper_config.json -w /r7-source metasploit-baseline-builder:latest /bin/bash -l
```

Inside the running docker instance I had to install pip:

```
pip install requests
```

Verifying the action is available (*change the prefix*):

```
$ cd /r7-source/vm-automation/samples
$ python ./samples/manageServices.py -k MYPREFIX_Win --actionFile /r7-source/vm-automation/samples/action_scripts/commands.json --listCommands /r7-source/helper_config.json
cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend
INSTALL_AVG
AUTOLOGIN_DISABLE
DEFENDER_SIGUPDATE
UAC_ENABLE
INSTALL_MALWAREBYTES
WSUS_DISABLE
DEFENDER_DISABLE
UAC_DISABLE
INSTALL_AVAST
AUTOLOGIN_ENABLE
SMB1_ENABLE
FIREWALL_DISABLE
SMB1_DISABLE
WSUS_ENABLE
INSTALL_ACTIVE_DIRECTORY_DOMAIN_SERVICES <------------------
FIREWALL_ENABLE
DEFENDER_ENABLE
```

Running the action with hard coded user/password values against the target machine (*change the prefix*):

```
cd /r7-source/vm-automation/samples
python /r7-source/vm-automation/samples/manageServices.py -k MYPREFIX_Win --actionFile /r7-source/vm-automation/samples/action_scripts/commands.json --action INSTALL_ACTIVE_DIRECTORY_DOMAIN_SERVICES --user vagrant --password vagrant /r7-source/helper_config.json
```

View the log files:

```
cat /r7-source/vm-automation/samples/logs/* 
```